### PR TITLE
Removes red highlight for commits behind mainline

### DIFF
--- a/src/styles/repo_list/release_state.css
+++ b/src/styles/repo_list/release_state.css
@@ -8,8 +8,12 @@
   font-size: 0.8em;
 }
 
+.release-state .commits-behind {
+  color: #CCC;
+}
+
 .release-state .commits-behind.behind {
-  color: #E64B4B;
+  color: #555;
 }
 
 .release-state .commits-behind .octicon {


### PR DESCRIPTION
Based on feedback, this will change the "commit behind mainline" indicator to a more subtle grey/black color scheme.
